### PR TITLE
feat(Teamlist-Landing) Automatically update the team list once a new team is created

### DIFF
--- a/store/Teams/saga.js
+++ b/store/Teams/saga.js
@@ -41,7 +41,7 @@ function* newTeamRequest({ payload }) {
   yield put(teamsActions.start());
   try {
     const { data: { data: { attributes: { name }, id } } } = yield call(apiTeams.newTeam, payload);
-    // yield put(teamsActions.addNewTeam({ newTeam: { name, id } }));
+    yield put(teamsActions.addNewTeam({ newTeam: { attributes: { name }, id } }));
   } catch (error) {
     console.log(error);
   }

--- a/store/Teams/slice.js
+++ b/store/Teams/slice.js
@@ -25,7 +25,7 @@ const slice = createSlice({
       state.currentTeam = action.payload.team;
     },
     addNewTeam(state, action) {
-      state.teamsList = [...state.teamsList, action.newTeam];
+      state.teamsList = [...state.teamsList, action.payload.newTeam];
     },
     finish(state) {
       state.loading = false;


### PR DESCRIPTION
Some minor changes so the team list in landing screen updates without a new request when a new team is created.